### PR TITLE
Only strip leading slashes from filenames when generating Cobertura reports

### DIFF
--- a/src/main/java/jscover/report/coberturaxml/CoberturaXmlGenerator.java
+++ b/src/main/java/jscover/report/coberturaxml/CoberturaXmlGenerator.java
@@ -427,7 +427,7 @@ public class CoberturaXmlGenerator {
             Element classElement = doc.createElement("class");
             classesElement.appendChild(classElement);
             classElement.setAttribute("name", file.getUri());
-            classElement.setAttribute("filename", file.getUri().substring(1));
+            classElement.setAttribute("filename", stripLeadingSlash(file.getUri()));
             classElement.setAttribute("line-rate", "" + file.getLineCoverRate());
             classElement.setAttribute("branch-rate", "" + file.getBranchRate());
             classElement.setAttribute("complexity", "0");
@@ -438,6 +438,10 @@ public class CoberturaXmlGenerator {
             FileData fileData = (FileData) file;
             addLines(doc, linesElement, fileData);
         }
+    }
+    
+    private String stripLeadingSlash(String filename) {
+        return filename.replaceFirst("^/", "");
     }
 
     private void addLines(Document doc, Element linesElement, FileData fileData) {


### PR DESCRIPTION
As described in issue #39, the leading slash in filenames is removed to ensure compatibility with Jenkins.

This works fine in web server mode when there is _always_ a leading slash present, but if you are converting a JSON coverage file that has been generated in file system mode (as per issue #48) then there are no leading slashes and the initial character of the filename is removed blindly.

This patch will only remove the initial character in a filename if it's a slash.
