### PR TITLE
Fix Content-Length return wrong length

### DIFF
--- a/src/main/java/jscover/server/HttpServer.java
+++ b/src/main/java/jscover/server/HttpServer.java
@@ -504,7 +504,7 @@ public class HttpServer extends Thread {
 
     protected void sendResponse(HTTP_STATUS status, MIME mime, String data) {
         sendPartialHeader(status, mime);
-        pw.write(format("Content-Length: %d\n\n", data.length()));
+        pw.write(format("Content-Length: %d\n\n", data.getBytes().length));
         pw.write(data);
         pw.flush();
     }


### PR DESCRIPTION
Hi, thanks for creating this awesome tool. I got a bug when using JSCover.

In Proxy mode, Content-Length return wrong length in some Unicode cases.

For example:
"小方".length() // Output: 2
"小方".getBytes("UTF-8").length // Output: 6

As `Content-Length` defines the size of the body,
in above case `data.length()` always return the shorter length, 
so **_the browser will cut the left JavaScript code**_ that causes syntax errors.
(Tested in chrome/Firefox).

Change to `data.getBytes().length`, parsing with bytes using the platform's default charset,
will get correct length.

*Content-Length Reference: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13
