### PR TITLE
Ugrade default JavaScript version to allow ES6 usage

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 1.1.1 / 2017-??-??
 ==================
   * Internal: Upgrade HtmlUnit 2.24 to 2.25, Mockito 2.7.5 to 2.7.14
+  * Upgraded default settings to allow ES6. JSCover currently uses Rhino 1.7.7 details can be found at (https://mozilla.github.io/rhino/compat/engines.html)
 
 1.1.0 / 2017-02-12
 ==================

--- a/src/main/java/jscover/ConfigurationCommon.java
+++ b/src/main/java/jscover/ConfigurationCommon.java
@@ -383,7 +383,7 @@ public class ConfigurationCommon extends Configuration {
     protected boolean isolateBrowser;
     protected final List<PatternMatcher> patternMatchers = new ArrayList<PatternMatcher>();
     private boolean includeUnloadedJS;
-    protected int JSVersion = Context.VERSION_1_5;
+    protected int JSVersion = Context.VERSION_ES6;
     protected CompilerEnvirons compilerEnvirons = new CompilerEnvirons();
     protected boolean defaultSkip;
     protected IoUtils ioUtils = IoUtils.getInstance();

--- a/src/main/resources/jscover/server/help.txt
+++ b/src/main/resources/jscover/server/help.txt
@@ -12,7 +12,7 @@ Options:
       --save-json-only          save only the coverage data, jscoverage.json
       --uri-to-file-matcher=REG for proxy mode, regular expression matcher for converting a URI to a file path
       --uri-to-file-replace=REP for proxy mode, regular expression replacement for converting a URI to a file path
-      --js-version=VERSION      JavaScript version 1.0, 1.2, ..., 1.8 (default: 1.3)
+      --js-version=VERSION      JavaScript version 1.0, 1.2, ..., 1.8, 2.0 (default: 2.0)
       --no-branch               turn off branch coverage data collection
       --no-function             turn off function coverage data collection
       --include-unloaded-js     include unloaded JavaScript under <document-root> in the report

--- a/src/test/java/jscover/ConfigurationCommonTest.java
+++ b/src/test/java/jscover/ConfigurationCommonTest.java
@@ -352,7 +352,7 @@ public class ConfigurationCommonTest {
 
     @Test
     public void shouldHaveDefaults() {
-        assertThat(config.getJSVersion(), is(150));
+        assertThat(config.getJSVersion(), is(200));
         assertThat(config.isIncludeUnloadedJS(), is(false));
         assertThat(config.isIncludeBranch(), is(true));
         assertThat(config.isIncludeFunction(), is(true));

--- a/src/test/java/jscover/filesystem/ConfigurationForFSTest.java
+++ b/src/test/java/jscover/filesystem/ConfigurationForFSTest.java
@@ -361,9 +361,9 @@ public class ConfigurationForFSTest {
         ConfigurationForFS configuration = ConfigurationForFS.parse(new String[]{"-fs", "src", "doc"});
         assertThat(configuration.showHelp(), is(false));
         assertThat(configuration.isInvalid(), is(false));
-        assertThat(configuration.getJSVersion(), equalTo(150));
+        assertThat(configuration.getJSVersion(), equalTo(200));
         assertThat(configuration.skipInstrumentation("/"), is(false));
-        assertThat(configuration.getCompilerEnvirons().getLanguageVersion(), equalTo(150));
+        assertThat(configuration.getCompilerEnvirons().getLanguageVersion(), equalTo(200));
         assertThat(configuration.isIncludeBranch(), is(true));
         assertThat(configuration.isIncludeFunction(), is(true));
         assertThat(configuration.getLogLevel(), is(SEVERE));

--- a/src/test/java/jscover/server/ConfigurationForServerTest.java
+++ b/src/test/java/jscover/server/ConfigurationForServerTest.java
@@ -363,9 +363,9 @@ public class ConfigurationForServerTest {
         assertThat(configuration.getDocumentRoot().toString(), equalTo(System.getProperty("user.dir")));
         assertThat(configuration.getPort(), equalTo(8080));
         assertThat(configuration.getReportDir(), is(new File(System.getProperty("user.dir"))));
-        assertThat(configuration.getJSVersion(), equalTo(150));
+        assertThat(configuration.getJSVersion(), equalTo(200));
         assertThat(configuration.skipInstrumentation("/"), is(false));
-        assertThat(configuration.getCompilerEnvirons().getLanguageVersion(), equalTo(150));
+        assertThat(configuration.getCompilerEnvirons().getLanguageVersion(), equalTo(200));
         assertThat(configuration.isProxy(), is(false));
         assertThat(configuration.isSaveJSONOnly(), is(false));
         assertThat(configuration.isIncludeBranch(), is(true));
@@ -399,7 +399,7 @@ public class ConfigurationForServerTest {
         assertThat(configuration.getDocumentRoot().toString(), equalTo(System.getProperty("user.dir")));
         assertThat(configuration.getPort(), equalTo(8080));
         assertThat(configuration.isProxy(), is(false));
-        assertThat(configuration.getJSVersion(), equalTo(150));
+        assertThat(configuration.getJSVersion(), equalTo(200));
         assertThat(configuration.skipInstrumentation("/"), is(false));
         assertThat(configuration.isIncludeBranch(), is(true));
         assertThat(configuration.isIncludeFunction(), is(true));

--- a/src/test/java/jscover/stdout/ConfigurationForStdOutTest.java
+++ b/src/test/java/jscover/stdout/ConfigurationForStdOutTest.java
@@ -358,9 +358,9 @@ public class ConfigurationForStdOutTest {
         ConfigurationForStdOut configuration = ConfigurationForStdOut.parse(new String[]{"-io", "doc/example/script.js"});
         assertThat(configuration.showHelp(), is(false));
         assertThat(configuration.isInvalid(), is(false));
-        assertThat(configuration.getJSVersion(), equalTo(150));
+        assertThat(configuration.getJSVersion(), equalTo(200));
         assertThat(configuration.skipInstrumentation("/"), is(false));
-        assertThat(configuration.getCompilerEnvirons().getLanguageVersion(), equalTo(150));
+        assertThat(configuration.getCompilerEnvirons().getLanguageVersion(), equalTo(200));
         assertThat(configuration.isIncludeBranch(), is(true));
         assertThat(configuration.isIncludeFunction(), is(true));
         assertThat(configuration.getLogLevel(), is(SEVERE));


### PR DESCRIPTION
I believe that JSCover is not the right tool or place to limit which JavaScript features can be used.

IMO JSCover should allow as much JavaScript features as possible by default.

WDYT?