### PR TITLE
Proxy Server, Change get request first line to end with /r/n instead of /n

### DIFF
--- a/src/main/java/jscover/server/ProxyService.java
+++ b/src/main/java/jscover/server/ProxyService.java
@@ -382,7 +382,7 @@ public class ProxyService {
             PrintWriter remotePrintWriter = new PrintWriter(remoteOutputStream);
 
             String uri = getRawURI(url);
-            remotePrintWriter.print(method + " " + uri + " HTTP/1.0\n");
+            remotePrintWriter.print(method + " " + uri + " HTTP/1.0\r\n");
             sendHeaders(request, remotePrintWriter);
             ioUtils.copyNoClose(remoteInputStream, os);
         } catch (IOException e) {


### PR DESCRIPTION
As per HTTP 1.0 standard, request lines should end with CR LF i.e. \r\n
https://www.w3.org/Protocols/HTTP/1.0/spec.html#Request-Line
 Request-Line   = Method SP Request-URI SP HTTP-Version CRLF

This was being followed in handleProxyPostOrPut but for Get request line was ended with \n
handleProxyRequest function line number 385
remotePrintWriter.print(method + " " + uri + " HTTP/1.0\n");

Because of this Get request was not working on some servers in proxy mode

Changed the code for Get request to end with \r\n as per standard